### PR TITLE
chore: rename to App for Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Unleash Slack App
+# Unleash App for Slack
 
-Add Unleash to your Slack workspace by using Unleash's official Slack App.
+Add Unleash to your Slack workspace by using Unleash's official App for Slack.
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 

--- a/app/components/Guide.tsx
+++ b/app/components/Guide.tsx
@@ -38,8 +38,8 @@ export const Guide = ({ access_token }: IGuideProps) => {
       </div>
       <p>
         You should copy this access token and paste it in the{' '}
-        <b>Access token</b> field you&apos;ll find in the Slack App integration
-        configuration inside your Unleash instance.
+        <b>Access token</b> field you&apos;ll find in the App for Slack
+        integration configuration inside your Unleash instance.
       </p>
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,9 @@ import { Inter } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Unleash Slack App',
+  title: 'Unleash App for Slack',
   description:
-    "Add Unleash to your Slack workspace by using Unleash's official Slack App."
+    "Add Unleash to your Slack workspace by using Unleash's official App for Slack."
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ export default async function Home({
             <h1 className='text-2xl font-bold'>Unleash</h1>
             <p className='text-gray-400'>
               Add Unleash to your Slack workspace by using Unleash&apos;s
-              official Slack App.
+              official App for Slack.
             </p>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-slack-app",
-  "description": "Add Unleash to your Slack workspace by using Unleash's official Slack App.",
+  "description": "Add Unleash to your Slack workspace by using Unleash's official App for Slack.",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3636/change-name-to-something-like-app-for-slack

Renames our "Slack App" to "App for Slack" in order to satisfy Slack Marketplace requirements.